### PR TITLE
bugs fix

### DIFF
--- a/Blackbone/src/BlackBone/ManualMap/MMap.cpp
+++ b/Blackbone/src/BlackBone/ManualMap/MMap.cpp
@@ -687,7 +687,7 @@ NTSTATUS MMap::RelocateImage( ImageContextPtr pImage )
     }
 
     // Dll can't be relocated
-    if (!(pImage->peImage.DllCharacteristics() & IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE))
+    if (!pImage->peImage.isSys() && !(pImage->peImage.DllCharacteristics() & IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE))
     {
         BLACKBONE_TRACE( L"ManualMap: Can't relocate image, no relocation flag" );
         return STATUS_INVALID_IMAGE_HASH;

--- a/Blackbone/src/BlackBone/PE/PEImage.h
+++ b/Blackbone/src/BlackBone/PE/PEImage.h
@@ -232,6 +232,12 @@ public:
     /// <returns>true if image is an *.exe</returns>
     BLACKBONE_API inline bool isExe() const { return _isExe; }
 
+	/// <summary>
+	/// Check if image is an executable file and not a sys
+	/// </summary>
+	/// <returns>true if image is an *.sys</returns>
+	BLACKBONE_API inline bool isSys() const { return _subsystem == IMAGE_SUBSYSTEM_NATIVE; }
+
     /// <summary>
     /// Check if image is pure IL image
     /// </summary>

--- a/Blackbone/src/BlackBone/PE/PEImage.h
+++ b/Blackbone/src/BlackBone/PE/PEImage.h
@@ -233,7 +233,7 @@ public:
     BLACKBONE_API inline bool isExe() const { return _isExe; }
 
 	/// <summary>
-	/// Check if image is an executable file and not a sys
+	/// Check if image is a sys file and not an exe or dll
 	/// </summary>
 	/// <returns>true if image is an *.sys</returns>
 	BLACKBONE_API inline bool isSys() const { return _subsystem == IMAGE_SUBSYSTEM_NATIVE; }


### PR DESCRIPTION
* Restore _isSys_ function lost in #10.
* Replace & with ==.

The old _isSys_ function still returns true for exe.
For exe, the value of __subsystem_ is 3 (_IMAGE_SUBSYSTEM_WINDOWS_CUI_).
Subsystem member is a value and not a binary flag.
So & should be replaced with ==.

https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_optional_header64#members